### PR TITLE
Refactor core

### DIFF
--- a/MetaCom-iOS/Core/Models/ChatRoomManager.swift
+++ b/MetaCom-iOS/Core/Models/ChatRoomManager.swift
@@ -14,7 +14,7 @@ import Foundation
 final class ChatRoomManager {
 	
 	private let connection: Connection
-	private var chats: Array<ChatRoom> = []
+	private var chats: [ChatRoom] = []
 	
 	/**
 		Create new `ChatManager` instance.

--- a/MetaCom-iOS/Core/Models/ChatRoomManager.swift
+++ b/MetaCom-iOS/Core/Models/ChatRoomManager.swift
@@ -13,7 +13,7 @@ import Foundation
 */
 final class ChatRoomManager {
 	
-	public let connection: Connection
+	private let connection: Connection
 	private var chats: Array<ChatRoom> = []
 	
 	/**
@@ -21,23 +21,23 @@ final class ChatRoomManager {
 		- parameters:
 			- connection: transport connection.
 	*/
-	init(_ connection: Connection) {
+	init(connection: Connection) {
 		self.connection = connection
 	}
 	
 	/**
 		Add new chatroom.
 		- parameters:
-			- id: chat name.
+			- name: chat name.
 			- completion: callback on completion.
 	*/
-	func add(id: String = Constants.roomDefault, completion: Callback? = nil) {
+	func addRoom(named name: String = Constants.roomDefault, completion: Completion? = nil) {
 		
-		let chat = ChatRoom(id, connection)
-		chat.join { (_, error) in
+		let chat = ChatRoom(name: name, connection: connection)
+		chat.join { (error) in
 			
 			defer {
-				completion?(nil, error)
+				completion?(error)
 			}
 			
 			guard error == nil else {
@@ -51,19 +51,19 @@ final class ChatRoomManager {
 	/**
 		Remove existing chatroom.
 		- parameters:
-			- id: chat name.
+			- name: chat name.
 	*/
-	func remove(_ id: String, completion: Callback? = nil) {
+	func removeRoom(named name: String, completion: Completion? = nil) {
 		
-		guard let index = chats.index(where: { $0.id == id }) else {
+		guard let index = chats.index(where: { $0.name == name }) else {
 			return
 		}
 		
 		let chat = chats[index]
-		chat.leave { (_, error) in
+		chat.leave { (error) in
 			
 			defer {
-				completion?(nil, error)
+				completion?(error)
 			}
 			
 			guard error == nil else {
@@ -75,12 +75,12 @@ final class ChatRoomManager {
 	}
 	
 	/**
-		Get chat by id.
+		Get chat by name.
 		- parameters:
-			- id: chat name.
+			- name: chat name.
 	*/
-	func get(by id: String) -> ChatRoom? {
+	func getRoom(named name: String) -> ChatRoom? {
 		
-		return (chats.filter { $0.id == id }).first
+		return (chats.filter { $0.name == name }).first
 	}
 }

--- a/MetaCom-iOS/Core/Models/UserConnection.swift
+++ b/MetaCom-iOS/Core/Models/UserConnection.swift
@@ -56,7 +56,7 @@ final class UserConnection {
 		let connection = Connection(config: config, delegate: self)
 		self.connection = connection
 		
-		chatManager = ChatRoomManager(self.connection)
+		chatManager = ChatRoomManager(connection: self.connection)
 		fileManager = FileManager(self.connection)
 		
 		self.connection.connect()

--- a/MetaCom-iOS/Core/Models/UserConnection.swift
+++ b/MetaCom-iOS/Core/Models/UserConnection.swift
@@ -61,6 +61,10 @@ final class UserConnection {
 		
 		self.connection.connect()
 	}
+	
+	deinit {
+		// TODO: Close `connection`
+	}
 }
 
 extension UserConnection: ConnectionDelegate {

--- a/MetaCom-iOS/Core/Models/UserConnectionManager.swift
+++ b/MetaCom-iOS/Core/Models/UserConnectionManager.swift
@@ -17,7 +17,7 @@ final class UserConnectionManager {
 	public static let instance = UserConnectionManager()
 	
 	/// List of user connections.
-	private(set) var userConnections: [UserConnection]
+	private(set) var userConnections: [UserConnection] = []
 	
 	/// Currently displayed connection.
 	private var currentUserConnection: UserConnection?
@@ -47,7 +47,6 @@ final class UserConnectionManager {
 		Create new `UserConnectionManager` instance.
 	*/
 	private init() {
- 		userConnections = []
 	}
 	
 	/**

--- a/MetaCom-iOS/Core/Models/UserConnectionManager.swift
+++ b/MetaCom-iOS/Core/Models/UserConnectionManager.swift
@@ -17,29 +17,29 @@ final class UserConnectionManager {
 	public static let instance = UserConnectionManager()
 	
 	/// List of user connections.
-	private(set) var userConnections: Array<UserConnection>
+	private(set) var userConnections: [UserConnection]
 	
 	/// Currently displayed connection.
-	private var currentConnection: UserConnection?
+	private var currentUserConnection: UserConnection?
 	
 	/**
 		Represents current connection the user works with.
 		Setting this property does nothing if the connection has been removed.
 	*/
-	public var current: UserConnection? {
+	public var currentConnection: UserConnection? {
 		get {
-			return currentConnection
+			return currentUserConnection
 		}
 		set(connection) {
 			
 			guard let aConnection = connection, userConnections.contains(aConnection) else {
 				if connection == nil {
-					currentConnection = nil
+					currentUserConnection = nil
 				}
 				return
 			}
 			
-			currentConnection = aConnection
+			currentUserConnection = aConnection
 		}
 	}
 	
@@ -56,7 +56,7 @@ final class UserConnectionManager {
 			- host: server host.
 			- port: server port.
 	*/
-	func add(host: String, port: Int) -> UserConnection {
+	func addConnection(host: String, port: Int) -> UserConnection {
 		
 		let id = (userConnections.last?.id ?? -1) + 1
 		let connection = UserConnection(id: id, host: host, port: port)
@@ -71,7 +71,7 @@ final class UserConnectionManager {
 		- parameters:
 			- connection: living connection.
 	*/
-	func remove(_ connection: UserConnection) {
+	func removeConnection(_ connection: UserConnection) {
 		
 		userConnections.remove(connection)
 	}

--- a/MetaCom-iOS/ViewControllers/ConnectionViewController.swift
+++ b/MetaCom-iOS/ViewControllers/ConnectionViewController.swift
@@ -44,7 +44,7 @@ class ConnectionViewController: UIViewController {
 		portTextField.isEnabled = false
 		
 		// TODO: Store conection
-		_ = UserConnectionManager.instance.add(host: host, port: port)
+		_ = UserConnectionManager.instance.addConnection(host: host, port: port)
 	}
 	
 	@objc private func didConnect(_ notification: Notification) {


### PR DESCRIPTION
I've changed some names, access levels and type aliases.

@GYFK if you are completely against such naming policy like `func removeRoom(named name: String, completion: Completion? = nil)` because it makes function call longer, I can propose to replace it with such variant `func remove(_ name: String, completion: Completion? = nil)`. But I think that the difference in the length isn't so critical and longer variant helps to understand what does the method actually do better.